### PR TITLE
Piecewise linear method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
 	"scipy",
 	"tqdm",
 	"pandas",
-	"pybind11"
+	"pybind11",
+	"emcee"
 	]
 version = "0.5.2"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.24.1
 scipy>=1.9.1
 tqdm>=4.61.2
 pandas>=1.3.1
+emcee>=3.1.2

--- a/src/fidanka/fiducial/fiducial.py
+++ b/src/fidanka/fiducial/fiducial.py
@@ -519,7 +519,7 @@ def renormalize(
         diff = np.concatenate((np.array([diff[0]]*int(neighbor_n/2)),diff,np.array([diff[-1]]*int(neighbor_n/2))))
         max_diff = max(diff)
 
-    repeat_time = [int(np.ceil(diff[i]/max_diff)) for i in range(len(df[0]))]
+    repeat_time = [int(np.ceil(diff[i]/(5*max_diff))) for i in range(len(df[0]))]
     repeat_idx = np.concatenate(tuple([np.array([i]*repeat_time[i]) for i in range(len(repeat_time))])).flatten()
     df = df[:,repeat_idx]
     filter1_renomalized = df[0]

--- a/src/fidanka/fiducial/fiducial.py
+++ b/src/fidanka/fiducial/fiducial.py
@@ -1326,9 +1326,17 @@ def fiducial_line(
     #     filter2 = shift_photometry_by_error(filter2, error2, baseSampling)
     #     color, mag = color_mag_from_filters(filter1, filter2, reverseFilterOrder)
     #     vColor = ff(mag) - color
-    
+
     import matplotlib.pyplot as plt
-    fig, axs = plt.subplots(1,2,figsize=(10,5))
+    fig, axs = plt.subplots(1,3,figsize=(15,5))	
+    axs[2].scatter(vColor, mag, s=1)	
+    axs[2].invert_yaxis()
+    mask = [np.abs(vColor[i]) < 3*np.sqrt(error1[i]**2 + error2[i]**2) for i in range(len(filter1))]	
+    filter1, error1, filter2, error2 = filter1[mask], error1[mask], filter2[mask], error2[mask]	
+
+    color, mag = color_mag_from_filters(filter1, filter2, reverseFilterOrder)	
+    vColor = ff(mag) - color	
+    binsLeft, binsRight = mag_bins(mag, percLow, percHigh, binSize, binSize_min=binSize_min)
     axs[0].scatter(vColor, mag, s=1)
     axs[1].scatter(color, mag, s=1)
     mag_ver = np.linspace(min(filter1),max(filter1),100)


### PR DESCRIPTION
Introduce the method utilizing mcmc to find the best-fit piecewise linear fiducial line.

Other changes: 
modify the uniform bin method. Set the uniform bin as default
remove the binSize option and replace with binSize_min to set the lower limit of binSize
add a cut to the data to remove points with large error after verticalized cmd
