### PR TITLE
Update deprecated numpy.distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-from numpy.distutils.core import setup
-from numpy.distutils.extension import Extension
+from setuptools import setup
+from setuptools import Extension
 
 
 class get_numpy_include(object):


### PR DESCRIPTION
Hi, this is a small change to replace the deprecated `numpy.distutils` with `setuptools`.

I haven't done any thorough testing, but this does at least fix installation with newer versions of `numpy` and doesn't seem to break `measure_fiducial_lines()`.

